### PR TITLE
見つけたバグの修正など

### DIFF
--- a/SmallPetsHealthcare/Config.h
+++ b/SmallPetsHealthcare/Config.h
@@ -56,7 +56,7 @@
 #define CH4 3
 #define CH4_TITLE "WHEEL(x)"
 #define CH4_GRAPH_MIN 0
-#define CH4_GRAPH_MAX 5000
+#define CH4_GRAPH_MAX 50000
 #define CH4_FS_MIN 1000
 #define CH4_FS_MAX 2000
 #define CH4_FG_MIN 2000
@@ -66,7 +66,7 @@
 #define CH5 4
 #define CH5_TITLE "HOUSE(x)"
 #define CH5_GRAPH_MIN 0
-#define CH5_GRAPH_MAX 100
+#define CH5_GRAPH_MAX 2000
 #define CH5_FS_MIN 5
 #define CH5_FS_MAX 20
 #define CH5_FG_MIN 20

--- a/SmallPetsHealthcare/MotionCountController.cpp
+++ b/SmallPetsHealthcare/MotionCountController.cpp
@@ -30,10 +30,9 @@ void MotionCountController::update() {
       pinDownTime = millis();
       motionTimeMsec += (pinDownTime - pinUpTime);
 
-
-      nowDayDataRef->sensorsValue[channel] = (int)motionTimeMsec / 60000;
-
     }
+
+    nowDayDataRef->sensorsValue[channel] = (int)motionTimeMsec / 60000;
 
     //debug output
     Serial.print("Motion pin: ");

--- a/SmallPetsHealthcare/UIGraphView.cpp
+++ b/SmallPetsHealthcare/UIGraphView.cpp
@@ -51,15 +51,15 @@ void UIGraphView::draw()
 
     for (int i = 0; i < 7; i++) 
     {
-        if(uiCellModelRef -> displayDataRef -> displayWeekly[i].sensorsValue[channel] > SENSOR_VALUE_NULL)
+        float fWeeklyValue = uiCellModelRef -> displayDataRef -> displayWeekly[i].sensorsValue[channel];
+        if(fWeeklyValue > graphMax) fWeeklyValue = graphMax;
+        if(fWeeklyValue > SENSOR_VALUE_NULL)
         {
-            graphY[i] = graphBottom - (int)(graphStd * (uiCellModelRef -> displayDataRef -> displayWeekly[i].sensorsValue[channel] - graphMin + 0.5));
-
+            graphY[i] = graphBottom - (int)(graphStd * (fWeeklyValue - graphMin + 0.5));
         }else
         {
            graphY[i] = graphBottom; 
         }
-        
     }
 
     for(int i = 0; i < 6; i++)

--- a/SmallPetsHealthcare/UIViewController.cpp
+++ b/SmallPetsHealthcare/UIViewController.cpp
@@ -166,6 +166,11 @@ void UIViewController::saveLogData()
 
 void UIViewController::reload()
 {
-    if(displayData.isToday == true) //
+    if(displayData.isToday == true)//表示が今日ならば表示更新
+    {
         displayDataController.today();
+        for (int i = 0; i < NUMBER_OF_SENSOR; i++) {
+            uiCells[i].updateGraf();
+        }
+    }
 }


### PR DESCRIPTION
- 0時の更新タイミングでグラフが再描画されないバグを修正
- 0時更新時のモーションカウントセンサー(Active)の値がリセットされないバグを修正
- グラフの最大値を超えた値の場合、グラフ外に線が伸びてしまい表示が見辛くなるので最大値にまるめこみ描画するように修正
- デフォルトのグラフ描画範囲が狭すぎたので修正